### PR TITLE
Redesign for the preparatory notification

### DIFF
--- a/.idea/dictionaries/sunyata.xml
+++ b/.idea/dictionaries/sunyata.xml
@@ -3,6 +3,7 @@
     <words>
       <w>argparse</w>
       <w>dellsén</w>
+      <w>descr</w>
       <w>drawrect</w>
       <w>graphicsscene</w>
       <w>graphicsview</w>
@@ -10,6 +11,7 @@
       <w>lxde</w>
       <w>mainwindow</w>
       <w>matc</w>
+      <w>notif</w>
       <w>pointf</w>
       <w>prio</w>
       <w>qaction</w>
@@ -25,6 +27,7 @@
       <w>qstyleoptiongraphicsitem</w>
       <w>qtimeline</w>
       <w>qtimer</w>
+      <w>qurl</w>
       <w>rectf</w>
       <w>sysinfo</w>
       <w>systray</w>

--- a/mc/db.py
+++ b/mc/db.py
@@ -59,8 +59,8 @@ def initial_schema_and_setup(i_db_conn: sqlite3.Connection) -> None:
         + " DEFAULT " + str(SQLITE_TRUE_INT) + ", "
         + Schema.SettingsTable.Cols.rest_reminder_interval + " INTEGER NOT NULL"
         + " DEFAULT " + str(DEFAULT_REST_REMINDER_INTERVAL_MINUTES_INT) + ", "
-        + Schema.SettingsTable.Cols.rest_reminder_audio_path + " TEXT NOT NULL"
-        + " DEFAULT '" + mc_global.get_user_audio_path(mc_global.WIND_CHIMES_FILENAME_STR) + "'" + ", "
+        + Schema.SettingsTable.Cols.rest_reminder_audio_filename + " TEXT NOT NULL"
+        + " DEFAULT '" + mc_global.WIND_CHIMES_FILENAME_STR + "'" + ", "
         + Schema.SettingsTable.Cols.rest_reminder_volume + " INTEGER NOT NULL"
         + " DEFAULT " + str(MAX_VOLUME_INT) + ", "
         + Schema.SettingsTable.Cols.rest_reminder_notification_type + " INTEGER NOT NULL"
@@ -69,8 +69,8 @@ def initial_schema_and_setup(i_db_conn: sqlite3.Connection) -> None:
         + " DEFAULT " + str(SQLITE_TRUE_INT) + ", "
         + Schema.SettingsTable.Cols.breathing_reminder_interval + " INTEGER NOT NULL"
         + " DEFAULT " + str(DEFAULT_BREATHING_REMINDER_INTERVAL_MINUTES_INT) + ", "
-        + Schema.SettingsTable.Cols.breathing_reminder_audio_path + " TEXT NOT NULL"
-        + " DEFAULT '" + mc_global.get_user_audio_path(mc_global.SMALL_BELL_SHORT_FILENAME_STR) + "'" + ", "
+        + Schema.SettingsTable.Cols.breathing_reminder_audio_filename + " TEXT NOT NULL"
+        + " DEFAULT '" + mc_global.SMALL_BELL_SHORT_FILENAME_STR + "'" + ", "
         + Schema.SettingsTable.Cols.breathing_reminder_volume + " INTEGER NOT NULL"
         + " DEFAULT " + str(MAX_VOLUME_INT) + ", "
         + Schema.SettingsTable.Cols.breathing_reminder_notification_type + " INTEGER NOT NULL"
@@ -87,6 +87,10 @@ def initial_schema_and_setup(i_db_conn: sqlite3.Connection) -> None:
         + " DEFAULT ''" + ", "
         + Schema.SettingsTable.Cols.breathing_dialog_phrase_selection + " INTEGER NOT NULL"
         + " DEFAULT " + str(mc_global.PhraseSelection.same.value) + ", "
+        + Schema.SettingsTable.Cols.prep_reminder_audio_filename + " TEXT NOT NULL"
+        + " DEFAULT '" + mc_global.SMALL_BELL_LONG_FILENAME_STR + "'" + ", "
+        + Schema.SettingsTable.Cols.prep_reminder_audio_volume + " INTEGER NOT NULL"
+        + " DEFAULT " + str(MAX_VOLUME_INT) + ", "
         + Schema.SettingsTable.Cols.run_on_startup + " INTEGER NOT NULL"
         + " DEFAULT " + str(SQLITE_FALSE_INT)
         + ")"
@@ -116,7 +120,7 @@ def upgrade_1_2(i_db_conn):
 
 
 upgrade_steps = {
-    20: initial_schema_and_setup,
+    22: initial_schema_and_setup,
 }
 
 
@@ -223,12 +227,12 @@ class Schema:
             id = "id"  # key
             rest_reminder_active = "rest_reminder_active"
             rest_reminder_interval = "rest_reminder_interval"
-            rest_reminder_audio_path = "rest_reminder_audio_path"
+            rest_reminder_audio_filename = "rest_reminder_audio_filename"
             rest_reminder_volume = "rest_reminder_volume"
             rest_reminder_notification_type = "rest_reminder_notification_type"
             breathing_reminder_active = "breathing_reminder_active"
             breathing_reminder_interval = "breathing_reminder_interval"
-            breathing_reminder_audio_path = "breathing_reminder_audio_path"
+            breathing_reminder_audio_filename = "breathing_reminder_audio_filename"
             breathing_reminder_volume = "breathing_reminder_volume"
             breathing_reminder_notification_type = "breathing_reminder_notification_type"
             breathing_reminder_phrase_setup = "breathing_reminder_phrase_setup"
@@ -237,6 +241,8 @@ class Schema:
             breathing_reminder_dialog_close_on_hover = "breathing_reminder_dialog_close_on_hover"
             breathing_reminder_text = "breathing_reminder_text"
             breathing_dialog_phrase_selection = "breathing_dialog_phrase_selection"
+            prep_reminder_audio_filename = "prep_reminder_audio_filename"
+            prep_reminder_audio_volume = "prep_reminder_audio_volume"
             run_on_startup = "run_on_startup"
 
 

--- a/mc/db.py
+++ b/mc/db.py
@@ -14,7 +14,7 @@ NO_BREATHING_REMINDER_INT = -1
 DEFAULT_REST_REMINDER_INTERVAL_MINUTES_INT = 30
 DEFAULT_BREATHING_REMINDER_INTERVAL_MINUTES_INT = 5
 SINGLE_SETTINGS_ID_INT = 0
-MAX_VOLUME_INT = 100
+DEFAULT_VOLUME_INT = 50
 DEFAULT_BREATHING_REMINDER_NR_BEFORE_DIALOG_INT = 3
 
 
@@ -62,7 +62,7 @@ def initial_schema_and_setup(i_db_conn: sqlite3.Connection) -> None:
         + Schema.SettingsTable.Cols.rest_reminder_audio_filename + " TEXT NOT NULL"
         + " DEFAULT '" + mc_global.WIND_CHIMES_FILENAME_STR + "'" + ", "
         + Schema.SettingsTable.Cols.rest_reminder_volume + " INTEGER NOT NULL"
-        + " DEFAULT " + str(MAX_VOLUME_INT) + ", "
+        + " DEFAULT " + str(DEFAULT_VOLUME_INT) + ", "
         + Schema.SettingsTable.Cols.rest_reminder_notification_type + " INTEGER NOT NULL"
         + " DEFAULT " + str(mc_global.NotificationType.Both.value) + ", "
         + Schema.SettingsTable.Cols.breathing_reminder_active + " INTEGER NOT NULL"
@@ -72,7 +72,7 @@ def initial_schema_and_setup(i_db_conn: sqlite3.Connection) -> None:
         + Schema.SettingsTable.Cols.breathing_reminder_audio_filename + " TEXT NOT NULL"
         + " DEFAULT '" + mc_global.SMALL_BELL_SHORT_FILENAME_STR + "'" + ", "
         + Schema.SettingsTable.Cols.breathing_reminder_volume + " INTEGER NOT NULL"
-        + " DEFAULT " + str(MAX_VOLUME_INT) + ", "
+        + " DEFAULT " + str(DEFAULT_VOLUME_INT) + ", "
         + Schema.SettingsTable.Cols.breathing_reminder_notification_type + " INTEGER NOT NULL"
         + " DEFAULT " + str(mc_global.NotificationType.Both.value) + ", "
         + Schema.SettingsTable.Cols.breathing_reminder_phrase_setup + " INTEGER NOT NULL"
@@ -90,7 +90,7 @@ def initial_schema_and_setup(i_db_conn: sqlite3.Connection) -> None:
         + Schema.SettingsTable.Cols.prep_reminder_audio_filename + " TEXT NOT NULL"
         + " DEFAULT '" + mc_global.SMALL_BELL_LONG_FILENAME_STR + "'" + ", "
         + Schema.SettingsTable.Cols.prep_reminder_audio_volume + " INTEGER NOT NULL"
-        + " DEFAULT " + str(MAX_VOLUME_INT) + ", "
+        + " DEFAULT " + str(DEFAULT_VOLUME_INT) + ", "
         + Schema.SettingsTable.Cols.run_on_startup + " INTEGER NOT NULL"
         + " DEFAULT " + str(SQLITE_FALSE_INT)
         + ")"

--- a/mc/gui/breathing_notification.py
+++ b/mc/gui/breathing_notification.py
@@ -49,7 +49,7 @@ class BreathingNotification(QtWidgets.QFrame):
 
         image_filename_str = "stones.png"
         if self.preparatory_bool:
-            image_filename_str = "flower-and-stones.png"
+            image_filename_str = "bikkhu-hands.png"
         self.image_qll.setPixmap(
             QtGui.QPixmap(mc.mc_global.get_user_images_path(image_filename_str))
         )

--- a/mc/gui/breathing_notification.py
+++ b/mc/gui/breathing_notification.py
@@ -23,7 +23,7 @@ class BreathingNotification(QtWidgets.QFrame):
     close_signal = QtCore.pyqtSignal()
     # wait_signal = QtCore.pyqtSignal()
 
-    def __init__(self):
+    def __init__(self, i_preparatory: bool=False):
         super().__init__(None, WINDOW_FLAGS)
 
         # self.setWindowFlags()
@@ -33,6 +33,8 @@ class BreathingNotification(QtWidgets.QFrame):
 
         # | QtCore.Qt.WindowStaysOnTopHint
         # | QtCore.Qt.X11BypassWindowManagerHint
+
+        self.preparatory_bool = i_preparatory
 
         self.setFocusPolicy(QtCore.Qt.NoFocus)
 
@@ -44,8 +46,12 @@ class BreathingNotification(QtWidgets.QFrame):
 
         self.image_qll = QtWidgets.QLabel()
         hbox_l2.addWidget(self.image_qll)
+
+        image_filename_str = "stones.png"
+        if self.preparatory_bool:
+            image_filename_str = "flower-and-stones.png"
         self.image_qll.setPixmap(
-            QtGui.QPixmap(mc.mc_global.get_user_images_path("stones.png"))
+            QtGui.QPixmap(mc.mc_global.get_user_images_path(image_filename_str))
         )
         self.image_qll.setScaledContents(True)
         self.resize_image()
@@ -53,11 +59,16 @@ class BreathingNotification(QtWidgets.QFrame):
         vbox_l3 = QtWidgets.QVBoxLayout()
         hbox_l2.addLayout(vbox_l3)
 
-        phrase = mc.model.PhrasesM.get(mc.mc_global.active_phrase_id_it)
-        self.ib_qll = QtWidgets.QLabel(phrase.ib)
-        vbox_l3.addWidget(self.ib_qll)
-        self.ob_qll = QtWidgets.QLabel(phrase.ob)
-        vbox_l3.addWidget(self.ob_qll)
+        if self.preparatory_bool:
+            self.prep_qll = QtWidgets.QLabel("Please slow down and prepare for your breathing break. Please adjust your posture")
+            self.prep_qll.setWordWrap(True)
+            vbox_l3.addWidget(self.prep_qll)
+        else:
+            phrase = mc.model.PhrasesM.get(mc.mc_global.active_phrase_id_it)
+            self.ib_qll = QtWidgets.QLabel(phrase.ib)
+            vbox_l3.addWidget(self.ib_qll)
+            self.ob_qll = QtWidgets.QLabel(phrase.ob)
+            vbox_l3.addWidget(self.ob_qll)
 
         hbox_l4 = QtWidgets.QHBoxLayout()
         vbox_l3.addLayout(hbox_l4)
@@ -96,7 +107,11 @@ class BreathingNotification(QtWidgets.QFrame):
         self.shown_qtimer.start(SHOWN_TIMER_TIME_INT)
 
     def shown_timer_timeout(self):
-        self.on_close_button_clicked()
+        if self.preparatory_bool:
+            self.breathe_signal.emit()
+            self.close()
+        else:
+            self.on_close_button_clicked()
 
     # overridden
     def mousePressEvent(self, i_qmouseevent):

--- a/mc/gui/breathing_prepare.py
+++ b/mc/gui/breathing_prepare.py
@@ -38,37 +38,6 @@ class BreathingPrepareDlg(QtWidgets.QFrame):
         self.reminder_qll.setFont(mc.mc_global.get_font_medium())
         vbox_l2.addWidget(self.reminder_qll)
 
-
-        """
-        self.time_remaining_qpb = QtWidgets.QProgressBar()
-        vbox_l2.addWidget(self.time_remaining_qpb)
-
-
-        hbox_l3 = QtWidgets.QHBoxLayout()
-        vbox_l2.addLayout(hbox_l3)
-
-        self.rest_qpb = QtWidgets.QPushButton(self.tr("Breathe"))
-        hbox_l3.addWidget(self.rest_qpb, stretch=1)
-        self.rest_qpb.setFont(mc.mc_global.get_font_large(i_bold=False))
-        # self.rest_qpb.clicked.connect(self.on_rest_button_clicked)
-        self.rest_qpb.setStyleSheet("background-color:" + mc.mc_global.MC_DARK_GREEN_COLOR_STR + "; color:#000000;")
-
-        hbox_l3.addStretch(1)
-        self.move_qpb = QtWidgets.QPushButton(self.tr("Move"))  # alt: Arrows for where to move
-        hbox_l3.addWidget(self.move_qpb)
-        self.move_qpb.setFlat(True)
-        self.wait_qpb = QtWidgets.QPushButton(self.tr("Wait"))
-        hbox_l3.addWidget(self.wait_qpb)
-        self.wait_qpb.setFlat(True)
-        # self.wait_qpb.clicked.connect(self.on_wait_button_clicked)
-        self.skip_qpb = QtWidgets.QPushButton(self.tr("Skip"))
-        hbox_l3.addWidget(self.skip_qpb)
-        self.skip_qpb.setFlat(True)
-        # self.skip_qpb.clicked.connect(self.on_skip_button_clicked)
-        hbox_l3.addStretch(1)
-
-        """
-
         self.show()  # -done after all the widget have been added so that the right size is set
         self.raise_()
         self.showNormal()
@@ -83,15 +52,6 @@ class BreathingPrepareDlg(QtWidgets.QFrame):
 
         self.shown_qtimer = None
         self.start_shown_timer()
-
-        ##### self.setStyleSheet("background-color: #101010; color: #999999;")
-
-        # self.setStyleSheet("QPushButton {background-color: red;}")
-        # border-style: outset;border-width: 2px;border-color: beige;
-        # self.setStyleSheet("QPushButton {border-style: solid;border-width: 1px;border-color: black;}")
-        # self.setStyleSheet("QPushButton:hover {background-color:green;}")
-
-    #TODO: On hover - moving
 
     def start_shown_timer(self):
         self.shown_qtimer = QtCore.QTimer(self)  # -please remember to send "self" to the timer
@@ -118,17 +78,3 @@ class BreathingPrepareDlg(QtWidgets.QFrame):
     # overridden
     def mousePressEvent(self, i_qmouseevent):
         self.close_prepare_frame()
-
-    """
-    def on_rest_button_clicked(self):
-        self.rest_signal.emit()
-        self.close()
-
-    def on_skip_button_clicked(self):
-        self.skip_signal.emit()
-        self.close()
-
-    def on_wait_button_clicked(self):
-        self.wait_signal.emit()
-        self.close()
-    """

--- a/mc/gui/breathing_settings_wt.py
+++ b/mc/gui/breathing_settings_wt.py
@@ -60,6 +60,20 @@ class BreathingSettingsWt(QtWidgets.QWidget):
         hbox_l4.addWidget(QtWidgets.QLabel(self.tr("minutes")))
         hbox_l4.addStretch(1)
 
+        vbox_l3.addWidget(self.h_line())
+        self.notif_select_audio_qpb = QtWidgets.QPushButton(self.tr("Select audio"))
+        vbox_l3.addWidget(self.notif_select_audio_qpb)
+        self.notif_select_audio_qpb.clicked.connect(self.on_notif_select_audio_clicked)
+        self.notif_audio_path_qll = QtWidgets.QLabel(NO_AUDIO_SELECTED_STR)
+        vbox_l3.addWidget(self.notif_audio_path_qll)
+        self.notif_audio_path_qll.setWordWrap(True)
+        self.notif_volume_qsr = QtWidgets.QSlider()
+        vbox_l3.addWidget(self.notif_volume_qsr)
+        self.notif_volume_qsr.setOrientation(QtCore.Qt.Horizontal)
+        self.notif_volume_qsr.setMinimum(0)
+        self.notif_volume_qsr.setMaximum(100)
+        self.notif_volume_qsr.valueChanged.connect(self.notif_volume_changed)
+
         """
         self.notification_text_qpb = QtWidgets.QPushButton("Set text")
         self.notification_text_qpb.clicked.connect(self.on_notification_text_button_clicked)
@@ -93,35 +107,29 @@ class BreathingSettingsWt(QtWidgets.QWidget):
         hbox_l4.addWidget(QtWidgets.QLabel(self.tr("notifications")))
         hbox_l4.addStretch(1)
 
+        """
         self.dialog_audio_qcb = QtWidgets.QCheckBox(self.tr("Play Audio"))
         vbox_l3.addWidget(self.dialog_audio_qcb)
         self.dialog_audio_qcb.toggled.connect(self.on_dialog_audio_toggled)
+        """
 
         self.dialog_close_on_hover_qcb = QtWidgets.QCheckBox(self.tr("Close on hover"))
         vbox_l3.addWidget(self.dialog_close_on_hover_qcb)
         self.dialog_close_on_hover_qcb.toggled.connect(self.on_dialog_close_on_hover_toggled)
 
-        self.test_breathing_dialog_qpb = QtWidgets.QPushButton(self.tr("Open breathing dialog"))
-        vbox_l3.addWidget(self.test_breathing_dialog_qpb)
-        self.test_breathing_dialog_qpb.clicked.connect(self.on_open_breathing_dialog_button_clicked)
-
-        # Audio
-        self.audio_qgb = QtWidgets.QGroupBox(self.tr("Audio"))
-        vbox_l2.addWidget(self.audio_qgb)
-        vbox_l3 = QtWidgets.QVBoxLayout()
-        self.audio_qgb.setLayout(vbox_l3)
-        self.select_audio_qpb = QtWidgets.QPushButton(self.tr("Select audio"))
-        vbox_l3.addWidget(self.select_audio_qpb)
-        self.select_audio_qpb.clicked.connect(self.on_select_audio_clicked)
-        self.audio_path_qll = QtWidgets.QLabel(NO_AUDIO_SELECTED_STR)
-        vbox_l3.addWidget(self.audio_path_qll)
-        self.audio_path_qll.setWordWrap(True)
-        self.volume_qsr = QtWidgets.QSlider()
-        vbox_l3.addWidget(self.volume_qsr)
-        self.volume_qsr.setOrientation(QtCore.Qt.Horizontal)
-        self.volume_qsr.setMinimum(0)
-        self.volume_qsr.setMaximum(100)
-        self.volume_qsr.valueChanged.connect(self.volume_changed)
+        vbox_l3.addWidget(self.h_line())
+        self.prep_select_audio_qpb = QtWidgets.QPushButton(self.tr("Select audio"))
+        vbox_l3.addWidget(self.prep_select_audio_qpb)
+        self.prep_select_audio_qpb.clicked.connect(self.on_prep_select_audio_clicked)
+        self.prep_audio_path_qll = QtWidgets.QLabel(NO_AUDIO_SELECTED_STR)
+        vbox_l3.addWidget(self.prep_audio_path_qll)
+        self.prep_audio_path_qll.setWordWrap(True)
+        self.prep_volume_qsr = QtWidgets.QSlider()
+        vbox_l3.addWidget(self.prep_volume_qsr)
+        self.prep_volume_qsr.setOrientation(QtCore.Qt.Horizontal)
+        self.prep_volume_qsr.setMinimum(0)
+        self.prep_volume_qsr.setMaximum(100)
+        self.prep_volume_qsr.valueChanged.connect(self.prep_volume_changed)
 
         vbox_l2.addStretch(1)
 
@@ -129,6 +137,11 @@ class BreathingSettingsWt(QtWidgets.QWidget):
         self.setDisabled(True)
 
         self.update_gui()
+
+    def h_line(self):
+        horizontal_line = QtWidgets.QFrame()
+        horizontal_line.setFrameShape(QtWidgets.QFrame.HLine)
+        return horizontal_line
 
     def on_phrase_selection_activated(self, i_index: int):
         # -activated is only triggered on user action
@@ -165,12 +178,17 @@ class BreathingSettingsWt(QtWidgets.QWidget):
             return
         mc.model.SettingsM.update_breathing_reminder_nr_per_dialog(i_new_value)
 
-    def volume_changed(self, i_value: int):
+    def prep_volume_changed(self, i_value: int):
+        if self.updating_gui_bool:
+            return
+        mc.model.SettingsM.update_prep_reminder_audio_volume(i_value)
+
+    def notif_volume_changed(self, i_value: int):
         if self.updating_gui_bool:
             return
         mc.model.SettingsM.update_breathing_reminder_volume(i_value)
 
-    def on_select_audio_clicked(self):
+    def on_prep_select_audio_clicked(self):
         # noinspection PyCallByClass
         audio_file_result_tuple = QtWidgets.QFileDialog.getOpenFileName(
             self,
@@ -181,30 +199,62 @@ class BreathingSettingsWt(QtWidgets.QWidget):
         new_file_path_str = audio_file_result_tuple[0]
         if new_file_path_str:
             new_filename_str = os.path.basename(new_file_path_str)  # -we store the name instead of the path
-            mc.model.SettingsM.update_breathing_reminder_audio_path(new_filename_str)
+            mc.model.SettingsM.update_prep_reminder_audio_filename(new_filename_str)
         else:
             pass
-        self.update_gui_audio_details()
+        self.prep_update_gui_audio_details()
+        self.notif_update_gui_audio_details()
 
-    def update_gui_audio_details(self):
+    def on_notif_select_audio_clicked(self):
+        # noinspection PyCallByClass
+        audio_file_result_tuple = QtWidgets.QFileDialog.getOpenFileName(
+            self,
+            self.tr("Please choose a wav audio file"),
+            mc_global.get_user_audio_path(),
+            self.tr("Wav files (*.wav)")
+        )
+        new_file_path_str = audio_file_result_tuple[0]
+        if new_file_path_str:
+            new_filename_str = os.path.basename(new_file_path_str)  # -we store the name instead of the path
+            mc.model.SettingsM.update_breathing_reminder_audio_filename(new_filename_str)
+        else:
+            pass
+        self.prep_update_gui_audio_details()
+        self.notif_update_gui_audio_details()
+
+    def prep_update_gui_audio_details(self):
+        self.updating_gui_bool = True
+        settings = mc.model.SettingsM.get()
+
+        audio_path_str = settings.prep_reminder_audio_filename
+        audio_file_name_str = os.path.basename(audio_path_str)
+        if audio_file_name_str:
+            self.prep_audio_path_qll.setText(audio_file_name_str)
+        else:
+            self.prep_audio_path_qll.setText(NO_AUDIO_SELECTED_STR)
+
+        #self.dialog_audio_qcb.setChecked(settings.breathing_reminder_dialog_audio_active_bool)
+        self.dialog_close_on_hover_qcb.setChecked(settings.breathing_reminder_dialog_close_on_active_bool)
+        self.prep_volume_qsr.setValue(settings.prep_reminder_audio_volume)
+
+        self.updating_gui_bool = False
+
+    def notif_update_gui_audio_details(self):
         self.updating_gui_bool = True
         settings = mc.model.SettingsM.get()
 
         audio_path_str = settings.breathing_reminder_audio_filename_str
         audio_file_name_str = os.path.basename(audio_path_str)
         if audio_file_name_str:
-            self.audio_path_qll.setText(audio_file_name_str)
+            self.notif_audio_path_qll.setText(audio_file_name_str)
         else:
-            self.audio_path_qll.setText(NO_AUDIO_SELECTED_STR)
+            self.notif_audio_path_qll.setText(NO_AUDIO_SELECTED_STR)
 
-        self.dialog_audio_qcb.setChecked(settings.breathing_reminder_dialog_audio_active_bool)
+        #self.dialog_audio_qcb.setChecked(settings.breathing_reminder_dialog_audio_active_bool)
         self.dialog_close_on_hover_qcb.setChecked(settings.breathing_reminder_dialog_close_on_active_bool)
-        self.volume_qsr.setValue(settings.breathing_reminder_volume_int)
+        self.notif_volume_qsr.setValue(settings.breathing_reminder_audio_volume_int)
 
         self.updating_gui_bool = False
-
-    def on_open_breathing_dialog_button_clicked(self):
-        self.breathe_now_button_clicked_signal.emit()
 
     def on_switch_toggled(self, i_checked_bool):
         if self.updating_gui_bool:
@@ -240,7 +290,8 @@ class BreathingSettingsWt(QtWidgets.QWidget):
         self.breathing_reminder_length_qsb.setValue(breathing_reminder_length_minutes_int)
         """
 
-        self.update_gui_audio_details()
+        self.prep_update_gui_audio_details()
+        self.notif_update_gui_audio_details()
 
         breathing_notification_type_enum = mc.mc_global.NotificationType(
             settings.breathing_reminder_notification_type_int
@@ -253,7 +304,7 @@ class BreathingSettingsWt(QtWidgets.QWidget):
             settings.breathing_reminder_phrase_setup_int
         )
 
-        self.dialog_audio_qcb.setChecked(settings.breathing_reminder_dialog_audio_active_bool)
+        #self.dialog_audio_qcb.setChecked(settings.breathing_reminder_dialog_audio_active_bool)
 
         self.notifications_per_dialog_qsb.setValue(
             settings.breathing_reminder_nr_before_dialog_int

--- a/mc/gui/breathing_settings_wt.py
+++ b/mc/gui/breathing_settings_wt.py
@@ -22,34 +22,36 @@ class BreathingSettingsWt(QtWidgets.QWidget):
 
         vbox_l2 = QtWidgets.QVBoxLayout()
         self.setLayout(vbox_l2)
-
         hbox_l3 = QtWidgets.QHBoxLayout()
         vbox_l2.addLayout(hbox_l3)
+
         self.toggle_switch = mc.gui.toggle_switch_wt.ToggleSwitchWt()
-        hbox_l3.addWidget(self.toggle_switch)
         self.toggle_switch.toggled_signal.connect(self.on_switch_toggled)
+        hbox_l3.addWidget(self.toggle_switch)
 
         # Notifications
+
         self.notifications_qgb = QtWidgets.QGroupBox(self.tr("Notifications"))
         vbox_l2.addWidget(self.notifications_qgb)
         vbox_l3 = QtWidgets.QVBoxLayout()
         self.notifications_qgb.setLayout(vbox_l3)
-
         hbox_l4 = QtWidgets.QHBoxLayout()
         vbox_l3.addLayout(hbox_l4)
+
         hbox_l4.addWidget(QtWidgets.QLabel(self.tr("Notification type: ")))
         hbox_l4.addStretch(1)
         self.notification_type_qcb = QtWidgets.QComboBox()
-        hbox_l4.addWidget(self.notification_type_qcb)
         self.notification_type_qcb.addItems([
             mc.mc_global.NotificationType.Visual.name,
             mc.mc_global.NotificationType.Audio.name,
             mc.mc_global.NotificationType.Both.name
         ])
         self.notification_type_qcb.activated.connect(self.on_notification_type_activated)
+        hbox_l4.addWidget(self.notification_type_qcb)
 
         hbox_l4 = QtWidgets.QHBoxLayout()
         vbox_l3.addLayout(hbox_l4)
+
         self.breathing_reminder_interval_qll = QtWidgets.QLabel(self.tr("Interval:"))
         hbox_l4.addWidget(self.breathing_reminder_interval_qll)
         self.breathing_reminder_interval_qsb = QtWidgets.QSpinBox()
@@ -62,25 +64,20 @@ class BreathingSettingsWt(QtWidgets.QWidget):
 
         vbox_l3.addWidget(self.h_line())
         self.notif_select_audio_qpb = QtWidgets.QPushButton(self.tr("Select audio"))
-        vbox_l3.addWidget(self.notif_select_audio_qpb)
         self.notif_select_audio_qpb.clicked.connect(self.on_notif_select_audio_clicked)
+        vbox_l3.addWidget(self.notif_select_audio_qpb)
         self.notif_audio_path_qll = QtWidgets.QLabel(NO_AUDIO_SELECTED_STR)
-        vbox_l3.addWidget(self.notif_audio_path_qll)
         self.notif_audio_path_qll.setWordWrap(True)
+        vbox_l3.addWidget(self.notif_audio_path_qll)
         self.notif_volume_qsr = QtWidgets.QSlider()
-        vbox_l3.addWidget(self.notif_volume_qsr)
         self.notif_volume_qsr.setOrientation(QtCore.Qt.Horizontal)
         self.notif_volume_qsr.setMinimum(0)
         self.notif_volume_qsr.setMaximum(100)
         self.notif_volume_qsr.valueChanged.connect(self.notif_volume_changed)
-
-        """
-        self.notification_text_qpb = QtWidgets.QPushButton("Set text")
-        self.notification_text_qpb.clicked.connect(self.on_notification_text_button_clicked)
-        vbox_l3.addWidget(self.notification_text_qpb)
-        """
+        vbox_l3.addWidget(self.notif_volume_qsr)
 
         # Dialog
+
         self.dialog_qgb = QtWidgets.QGroupBox(self.tr("Dialog"))
         vbox_l2.addWidget(self.dialog_qgb)
         vbox_l3 = QtWidgets.QVBoxLayout()
@@ -107,34 +104,25 @@ class BreathingSettingsWt(QtWidgets.QWidget):
         hbox_l4.addWidget(QtWidgets.QLabel(self.tr("notifications")))
         hbox_l4.addStretch(1)
 
-        """
-        self.dialog_audio_qcb = QtWidgets.QCheckBox(self.tr("Play Audio"))
-        vbox_l3.addWidget(self.dialog_audio_qcb)
-        self.dialog_audio_qcb.toggled.connect(self.on_dialog_audio_toggled)
-        """
-
         self.dialog_close_on_hover_qcb = QtWidgets.QCheckBox(self.tr("Close on hover"))
-        vbox_l3.addWidget(self.dialog_close_on_hover_qcb)
         self.dialog_close_on_hover_qcb.toggled.connect(self.on_dialog_close_on_hover_toggled)
+        vbox_l3.addWidget(self.dialog_close_on_hover_qcb)
 
         vbox_l3.addWidget(self.h_line())
         self.prep_select_audio_qpb = QtWidgets.QPushButton(self.tr("Select audio"))
-        vbox_l3.addWidget(self.prep_select_audio_qpb)
         self.prep_select_audio_qpb.clicked.connect(self.on_prep_select_audio_clicked)
+        vbox_l3.addWidget(self.prep_select_audio_qpb)
         self.prep_audio_path_qll = QtWidgets.QLabel(NO_AUDIO_SELECTED_STR)
-        vbox_l3.addWidget(self.prep_audio_path_qll)
         self.prep_audio_path_qll.setWordWrap(True)
+        vbox_l3.addWidget(self.prep_audio_path_qll)
         self.prep_volume_qsr = QtWidgets.QSlider()
-        vbox_l3.addWidget(self.prep_volume_qsr)
         self.prep_volume_qsr.setOrientation(QtCore.Qt.Horizontal)
         self.prep_volume_qsr.setMinimum(0)
         self.prep_volume_qsr.setMaximum(100)
         self.prep_volume_qsr.valueChanged.connect(self.prep_volume_changed)
+        vbox_l3.addWidget(self.prep_volume_qsr)
 
         vbox_l2.addStretch(1)
-
-        # self.breathing_reminder_qgb.setDisabled(True)  # -disabled until a phrase has been selected
-        self.setDisabled(True)
 
         self.update_gui()
 
@@ -144,16 +132,8 @@ class BreathingSettingsWt(QtWidgets.QWidget):
         return horizontal_line
 
     def on_phrase_selection_activated(self, i_index: int):
-        # -activated is only triggered on user action
+        # -activated is only triggered on user action (and not programmatically)
         mc.model.SettingsM.update_breathing_dialog_phrase_selection(i_index)
-
-    """
-    def on_notification_text_button_clicked(self):
-        if self.updating_gui_bool:
-            return
-        return_text_str = QtWidgets.QInputDialog.getMultiLineText(self, "Multi line text dialog", "text", "text")
-        asdf
-    """
 
     def on_dialog_close_on_hover_toggled(self, i_checked: bool):
         if self.updating_gui_bool:
@@ -166,11 +146,11 @@ class BreathingSettingsWt(QtWidgets.QWidget):
         mc.model.SettingsM.update_breathing_dialog_audio_active(i_checked)
 
     def on_phrase_setup_activated(self, i_index: int):
-        # -activated is only triggered on user action
+        # -activated is only triggered on user action (and not programmatically)
         mc.model.SettingsM.update_breathing_reminder_notification_phrase_setup(i_index)
 
     def on_notification_type_activated(self, i_index: int):
-        # -activated is only triggered on user action
+        # -activated is only triggered on user action (and not programmatically)
         mc.model.SettingsM.update_breathing_reminder_notification_type(i_index)
 
     def on_notifications_per_dialog_qsb_changed(self, i_new_value: int):
@@ -198,12 +178,11 @@ class BreathingSettingsWt(QtWidgets.QWidget):
         )
         new_file_path_str = audio_file_result_tuple[0]
         if new_file_path_str:
-            new_filename_str = os.path.basename(new_file_path_str)  # -we store the name instead of the path
+            new_filename_str = os.path.basename(new_file_path_str)  # -we store the name rather than the path
             mc.model.SettingsM.update_prep_reminder_audio_filename(new_filename_str)
         else:
             pass
         self.prep_update_gui_audio_details()
-        self.notif_update_gui_audio_details()
 
     def on_notif_select_audio_clicked(self):
         # noinspection PyCallByClass
@@ -219,7 +198,6 @@ class BreathingSettingsWt(QtWidgets.QWidget):
             mc.model.SettingsM.update_breathing_reminder_audio_filename(new_filename_str)
         else:
             pass
-        self.prep_update_gui_audio_details()
         self.notif_update_gui_audio_details()
 
     def prep_update_gui_audio_details(self):
@@ -233,7 +211,6 @@ class BreathingSettingsWt(QtWidgets.QWidget):
         else:
             self.prep_audio_path_qll.setText(NO_AUDIO_SELECTED_STR)
 
-        #self.dialog_audio_qcb.setChecked(settings.breathing_reminder_dialog_audio_active_bool)
         self.dialog_close_on_hover_qcb.setChecked(settings.breathing_reminder_dialog_close_on_active_bool)
         self.prep_volume_qsr.setValue(settings.prep_reminder_audio_volume)
 
@@ -250,7 +227,6 @@ class BreathingSettingsWt(QtWidgets.QWidget):
         else:
             self.notif_audio_path_qll.setText(NO_AUDIO_SELECTED_STR)
 
-        #self.dialog_audio_qcb.setChecked(settings.breathing_reminder_dialog_audio_active_bool)
         self.dialog_close_on_hover_qcb.setChecked(settings.breathing_reminder_dialog_close_on_active_bool)
         self.notif_volume_qsr.setValue(settings.breathing_reminder_audio_volume_int)
 
@@ -270,44 +246,19 @@ class BreathingSettingsWt(QtWidgets.QWidget):
 
     def update_gui(self):
         self.updating_gui_bool = True
-
         settings = mc.model.SettingsM.get()
-
-        # Breathing reminder
         if mc_global.active_phrase_id_it != mc_global.NO_PHRASE_SELECTED_INT:
             self.setDisabled(False)
         else:
             self.setDisabled(True)
 
-        br_enabled = settings.breathing_reminder_active_bool
-        self.toggle_switch.update_gui(br_enabled)
-
-
-        breathing_reminder_interval_minutes_int = settings.breathing_reminder_interval_int
-        self.breathing_reminder_interval_qsb.setValue(breathing_reminder_interval_minutes_int)
-        """
-        breathing_reminder_length_minutes_int = model.SettingsM.get().breathing_reminder_length_int
-        self.breathing_reminder_length_qsb.setValue(breathing_reminder_length_minutes_int)
-        """
+        self.toggle_switch.update_gui(settings.breathing_reminder_active_bool)
+        self.breathing_reminder_interval_qsb.setValue(settings.breathing_reminder_interval_int)
+        self.notification_type_qcb.setCurrentText(settings.breathing_reminder_notification_type.name)
+        self.phrase_selection_qcb.setCurrentText(settings.breathing_dialog_phrase_selection.name)
+        self.notifications_per_dialog_qsb.setValue(settings.breathing_reminder_nr_before_dialog_int)
 
         self.prep_update_gui_audio_details()
         self.notif_update_gui_audio_details()
-
-        breathing_notification_type_enum = mc.mc_global.NotificationType(
-            settings.breathing_reminder_notification_type_int
-        )
-        self.notification_type_qcb.setCurrentText(breathing_notification_type_enum.name)
-
-        self.phrase_selection_qcb.setCurrentText(settings.breathing_dialog_phrase_selection.name)
-
-        phrase_setup_enum = mc.mc_global.PhraseSetup(
-            settings.breathing_reminder_phrase_setup_int
-        )
-
-        #self.dialog_audio_qcb.setChecked(settings.breathing_reminder_dialog_audio_active_bool)
-
-        self.notifications_per_dialog_qsb.setValue(
-            settings.breathing_reminder_nr_before_dialog_int
-        )
 
         self.updating_gui_bool = False

--- a/mc/gui/main_win.py
+++ b/mc/gui/main_win.py
@@ -579,8 +579,15 @@ class MainWin(QtWidgets.QMainWindow):
             self._play_audio(audio_path_str, volume_int)
 
     def open_breathing_prepare(self):
+
+        self.breathing_notification = mc.gui.breathing_notification.BreathingNotification(i_preparatory=True)
+        self.breathing_notification.breathe_signal.connect(self.on_breathing_notification_breathe_clicked)
+        self.breathing_notification.show()
+
+        """
         self.breathing_prepare = mc.gui.breathing_prepare.BreathingPrepareDlg()
         self.breathing_prepare.closed_signal.connect(self.open_breathing_dialog)
+        """
 
     def open_breathing_dialog(self, i_mute_override: bool=False):
 

--- a/mc/gui/main_win.py
+++ b/mc/gui/main_win.py
@@ -575,14 +575,28 @@ class MainWin(QtWidgets.QMainWindow):
         or notification_type_int == mc.mc_global.NotificationType.Audio.value):
             settings = mc.model.SettingsM.get()
             audio_path_str = settings.breathing_reminder_audio_filename_str
-            volume_int = settings.breathing_reminder_volume_int
+            volume_int = settings.breathing_reminder_audio_volume_int
             self._play_audio(audio_path_str, volume_int)
 
     def open_breathing_prepare(self):
+        # Skipping the breathing notification if the breathing dialog is shown
+        if self.breathing_dialog and self.breathing_dialog.isVisible():
+            return
 
-        self.breathing_notification = mc.gui.breathing_notification.BreathingNotification(i_preparatory=True)
-        self.breathing_notification.breathe_signal.connect(self.on_breathing_notification_breathe_clicked)
-        self.breathing_notification.show()
+        notification_type_int = mc.model.SettingsM.get().breathing_reminder_notification_type_int
+
+        if (notification_type_int == mc.mc_global.NotificationType.Both.value
+        or notification_type_int == mc.mc_global.NotificationType.Visual.value):
+            self.breathing_notification = mc.gui.breathing_notification.BreathingNotification(i_preparatory=True)
+            self.breathing_notification.breathe_signal.connect(self.on_breathing_notification_breathe_clicked)
+            self.breathing_notification.show()
+
+        if (notification_type_int == mc.mc_global.NotificationType.Both.value
+        or notification_type_int == mc.mc_global.NotificationType.Audio.value):
+            settings = mc.model.SettingsM.get()
+            audio_path_str = settings.prep_reminder_audio_filename
+            volume_int = settings.prep_reminder_audio_volume
+            self._play_audio(audio_path_str, volume_int)
 
         """
         self.breathing_prepare = mc.gui.breathing_prepare.BreathingPrepareDlg()
@@ -602,12 +616,6 @@ class MainWin(QtWidgets.QMainWindow):
         self.breathing_dialog.close_signal.connect(self.on_breathing_dialog_closed)
         self.breathing_dialog.phrase_changed_signal.connect(self.on_breathing_dialog_phrase_changed)
         self.breathing_dialog.show()
-
-        settings = mc.model.SettingsM.get()
-        if settings.breathing_reminder_dialog_audio_active_bool and not i_mute_override:
-            audio_path_str = settings.breathing_reminder_audio_filename_str
-            volume_int = settings.breathing_reminder_volume_int
-            self._play_audio(audio_path_str, volume_int)
 
     def _play_audio(self, i_audio_filename: str, i_volume: int) -> None:
         if self.sound_effect is None:

--- a/mc/mc_global.py
+++ b/mc/mc_global.py
@@ -30,6 +30,7 @@ OPEN_ICONIC_ICONS_DIR_STR = "open_iconic"
 AUDIO_DIR_STR = "audio"
 
 SMALL_BELL_SHORT_FILENAME_STR = "small_bell_short[cc0].wav"
+SMALL_BELL_LONG_FILENAME_STR = "small_bell_long[cc0].wav"
 WIND_CHIMES_FILENAME_STR = "wind_chimes[cc0].wav"
 
 active_rest_action_id_it = NO_REST_ACTION_SELECTED_INT

--- a/mc/model.py
+++ b/mc/model.py
@@ -453,7 +453,7 @@ class SettingsM:
         i_breathing_reminder_active: int,
         i_breathing_reminder_interval: int,
         i_breathing_reminder_audio_filename: str,
-        i_breathing_reminder_volume: int,
+        i_breathing_reminder_audio_volume: int,
         i_breathing_reminder_notification_type: int,
         i_breathing_reminder_phrase_setup: int,
         i_breathing_reminder_nr_before_dialog: int,
@@ -461,6 +461,8 @@ class SettingsM:
         i_breathing_reminder_dialog_close_on_active: int,
         i_breathing_reminder_text: str,
         i_breathing_dialog_phrase_selection: int,
+        i_prep_reminder_audio_filename: str,
+        i_prep_reminder_audio_volume: int,
         i_run_on_startup: int
     ) -> None:
         self.rest_reminder_active_bool = True if i_rest_reminder_active else False
@@ -471,7 +473,7 @@ class SettingsM:
         self.breathing_reminder_active_bool = True if i_breathing_reminder_active else False
         self.breathing_reminder_interval_int = i_breathing_reminder_interval
         self.breathing_reminder_audio_filename_str = i_breathing_reminder_audio_filename
-        self.breathing_reminder_volume_int = i_breathing_reminder_volume
+        self.breathing_reminder_audio_volume_int = i_breathing_reminder_audio_volume
         self.breathing_reminder_notification_type_int = i_breathing_reminder_notification_type
         self.breathing_reminder_phrase_setup_int = i_breathing_reminder_phrase_setup
         self.breathing_reminder_nr_before_dialog_int = i_breathing_reminder_nr_before_dialog
@@ -480,7 +482,25 @@ class SettingsM:
             True if i_breathing_reminder_dialog_close_on_active else False
         self.breathing_reminder_text_str = i_breathing_reminder_text
         self.breathing_dialog_phrase_selection_int = i_breathing_dialog_phrase_selection
+        self.prep_reminder_audio_filename_str = i_prep_reminder_audio_filename
+        self.prep_reminder_audio_volume_int = i_prep_reminder_audio_volume
         self.run_on_startup_bool = True if i_run_on_startup else False
+
+    @property
+    def prep_reminder_audio_volume(self) -> int:
+        return self.prep_reminder_audio_volume_int
+
+    @prep_reminder_audio_volume.setter
+    def prep_reminder_audio_volume(self, i_new_prep_reminder_audio_volume):
+        self.prep_reminder_audio_volume_int = i_new_prep_reminder_audio_volume
+
+    @property
+    def prep_reminder_audio_filename(self) -> str:
+        return self.prep_reminder_audio_filename_str
+
+    @prep_reminder_audio_filename.setter
+    def prep_reminder_audio_filename(self, i_new_prep_reminder_audio_filename: str):
+        self.prep_reminder_audio_filename_str = i_new_prep_reminder_audio_filename
 
     @property
     def breathing_dialog_phrase_selection(self) -> mc.mc_global.PhraseSelection:
@@ -512,15 +532,15 @@ class SettingsM:
         )
 
     @property
-    def rest_reminder_audio_path(self) -> str:
-        return self.rest_reminder_audio_path
+    def rest_reminder_audio_filename(self) -> str:
+        return self.rest_reminder_audio_filename
 
-    @rest_reminder_audio_path.setter
-    def rest_reminder_audio_path(self, i_new_path: str) -> None:
-        self.rest_reminder_audio_filename_str = i_new_path
+    @rest_reminder_audio_filename.setter
+    def rest_reminder_audio_filename(self, i_new_filename: str) -> None:
+        self.rest_reminder_audio_filename_str = i_new_filename
         self._update(
-            db.Schema.SettingsTable.Cols.rest_reminder_audio_path,
-            i_new_path
+            db.Schema.SettingsTable.Cols.rest_reminder_audio_filename,
+            i_new_filename
         )
 
     @property
@@ -590,10 +610,10 @@ class SettingsM:
         # -the asterisk (*) will "expand" the tuple into separate arguments for the function header
 
     @staticmethod
-    def update_rest_reminder_audio_path(i_new_audio_path: str) -> None:
+    def update_rest_reminder_audio_filename(i_new_audio_filename: str) -> None:
         SettingsM._update(
-            db.Schema.SettingsTable.Cols.rest_reminder_audio_path,
-            i_new_audio_path
+            db.Schema.SettingsTable.Cols.rest_reminder_audio_filename,
+            i_new_audio_filename
         )
 
     @staticmethod
@@ -655,16 +675,30 @@ class SettingsM:
         )
 
     @staticmethod
-    def update_breathing_reminder_audio_path(i_new_audio_path: str) -> None:
+    def update_prep_reminder_audio_filename(i_new_audio_filename: str) -> None:
         SettingsM._update(
-            db.Schema.SettingsTable.Cols.breathing_reminder_audio_path,
-            i_new_audio_path
+            db.Schema.SettingsTable.Cols.prep_reminder_audio_filename,
+            i_new_audio_filename
+        )
+
+    @staticmethod
+    def update_breathing_reminder_audio_filename(i_new_audio_filename: str) -> None:
+        SettingsM._update(
+            db.Schema.SettingsTable.Cols.breathing_reminder_audio_filename,
+            i_new_audio_filename
         )
 
     @staticmethod
     def update_breathing_reminder_volume(i_new_volume: int) -> None:
         SettingsM._update(
             db.Schema.SettingsTable.Cols.breathing_reminder_volume,
+            i_new_volume
+        )
+
+    @staticmethod
+    def update_prep_reminder_audio_volume(i_new_volume: int) -> None:
+        SettingsM._update(
+            db.Schema.SettingsTable.Cols.prep_reminder_audio_volume,
             i_new_volume
         )
 

--- a/mc/model.py
+++ b/mc/model.py
@@ -487,6 +487,13 @@ class SettingsM:
         self.run_on_startup_bool = True if i_run_on_startup else False
 
     @property
+    def breathing_reminder_notification_type(self):
+        ret_breathing_notification_type_enum = mc.mc_global.NotificationType(
+            self.breathing_reminder_notification_type_int
+        )
+        return ret_breathing_notification_type_enum
+
+    @property
     def prep_reminder_audio_volume(self) -> int:
         return self.prep_reminder_audio_volume_int
 


### PR DESCRIPTION
Now the previous dialog has been removed, and instead we are using the breathing notification to hold the same text, and the breathing dialog is also changed by showing the breathing dialog when it times out (rather than just closing with nothing else happening). Also we have set a different image for the preparatory notification

WIP, still to do:
* [x] We need to determine how the audio will work
* [x] We need to clean up / change the settings window