### PR TITLE
Warning dialog on empty new item

### DIFF
--- a/mc/gui/breathing_phrase_list_wt.py
+++ b/mc/gui/breathing_phrase_list_wt.py
@@ -3,6 +3,7 @@ from PyQt5 import QtCore
 from PyQt5 import QtGui
 from PyQt5 import QtWidgets
 import mc.gui.safe_delete_dlg
+import mc.gui.warning_dlg
 import mc.model
 import mc.mc_global
 
@@ -199,6 +200,9 @@ class BreathingPhraseListWt(QtWidgets.QWidget):
     def add_new_phrase_button_clicked(self):
         text_sg = self.add_to_list_qle.text().strip()  # strip is needed to remove a newline at the end (why?)
         if not (text_sg and text_sg.strip()):
+            conf_result_bool = mc.gui.warning_dlg.WarningDlg.get_safe_confirmation_dialog(
+                self.tr("You have to write an item before you press 'Add'.")
+            )
             return
         mc.model.PhrasesM.add(
             text_sg,

--- a/mc/gui/rest_action_list_wt.py
+++ b/mc/gui/rest_action_list_wt.py
@@ -5,6 +5,7 @@ from PyQt5 import QtCore
 from PyQt5 import QtGui
 from PyQt5 import QtWidgets
 import mc.gui.safe_delete_dlg
+import mc.gui.warning_dlg
 from mc import model, mc_global
 
 
@@ -115,6 +116,9 @@ class RestActionListWt(QtWidgets.QWidget):
 
     def add_rest_action_clicked(self):
         if not(self.rest_add_action_qle.text().strip()):
+            conf_result_bool = mc.gui.warning_dlg.WarningDlg.get_safe_confirmation_dialog(
+                self.tr("You have to write an item before you press 'Add'.")
+            )
             return
         model.RestActionsM.add(
             self.rest_add_action_qle.text().strip()

--- a/mc/gui/warning_dlg.py
+++ b/mc/gui/warning_dlg.py
@@ -1,0 +1,34 @@
+from PyQt5 import QtWidgets
+from PyQt5 import QtCore
+
+
+class WarningDlg(QtWidgets.QDialog):
+    """
+    Inspiration: Answer by lou here:
+    https://stackoverflow.com/questions/18196799/how-can-i-show-a-pyqt-modal-dialog-and-get-data-out-of-its-controls-once-its-clo
+    """
+    def __init__(self, i_description_str: str, i_parent=None) -> None:
+        super(WarningDlg, self).__init__(i_parent)
+
+        vbox = QtWidgets.QVBoxLayout(self)
+
+        self.description_qll = QtWidgets.QLabel(i_description_str)
+        vbox.addWidget(self.description_qll)
+
+        self.button_box = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.Ok ,
+            QtCore.Qt.Horizontal,
+            self
+        )
+        vbox.addWidget(self.button_box)
+        self.button_box.accepted.connect(self.accept)
+        # -accept and reject are "slots" built into Qt
+
+    @staticmethod
+    def get_safe_confirmation_dialog(i_description_str: str) -> bool:
+        dialog = WarningDlg(i_description_str)
+        dialog_result = dialog.exec_()
+        confirmation_result_bool = False
+        if dialog_result == QtWidgets.QDialog.Accepted:
+            confirmation_result_bool = True
+        return confirmation_result_bool


### PR DESCRIPTION
Create warning_dlg.py base on safe_delete_dlg.py and modify rest_action_list_wt.py and breathing_phrase_list_wt.py. The aim is to inform the users what they have to do if they press the button 'Add' without adding a new item. The warning_dlg.pycreates the dialog. In rest_action_list_wt.py and breathing_phrase_list_wt.py I import the mc.gui.warning_dlg. In add_new_phrase_button_clicked method and in add_rest_action_clicked method i call the mc.gui.warning_dlg to connect with the dialog and to create the message that this dialog would have.