### PR TITLE
Set tooltip to on/off_qpb.

### DIFF
--- a/mc/gui/toggle_switch_wt.py
+++ b/mc/gui/toggle_switch_wt.py
@@ -22,12 +22,14 @@ class ToggleSwitchWt(QtWidgets.QWidget):
         hbox.addWidget(self.on_qpb)
         self.on_qpb.setFixedWidth(40)
         self.on_qpb.setCheckable(True)
+        self.on_qpb.setToolTip(self.tr("Enable notification"))
         self.on_qpb.toggled.connect(self.on_on_toggled)
 
         self.off_qpb = QtWidgets.QPushButton(self.tr("Off"))
         hbox.addWidget(self.off_qpb)
         self.off_qpb.setFixedWidth(45)
         self.off_qpb.setCheckable(True)
+        self.off_qpb.setToolTip(self.tr("Disable notification"))
         self.off_qpb.toggled.connect(self.on_off_toggled)
 
         self.state_qll = QtWidgets.QLabel(self.tr("Enabled"))


### PR DESCRIPTION
Modify toggle_switch_wt.py. Set a tooltip to on_qpb and to off_qpb to infrom the users what these buttons do without pressing them.