### PR TITLE
Added tooltip to the systray icon showing the time left until the next rest

### DIFF
--- a/mc/gui/main_win.py
+++ b/mc/gui/main_win.py
@@ -74,6 +74,8 @@ class MainWin(QtWidgets.QMainWindow):
         self._setup_add_first_panel_to_main_container(main_container_hbox_l3)
         self._setup_add_breathing_phrase_list_to_main_container(main_container_hbox_l3)
         self._setup_add_rest_action_list_to_main_container(main_container_hbox_l3)
+        
+        self.setup_systray()
 
         # Setup of Menu
         self.menu_bar = self.menuBar()
@@ -87,8 +89,6 @@ class MainWin(QtWidgets.QMainWindow):
         if not mc.mc_global.db_file_exists_at_application_startup_bl and not mc.mc_global.testing_bool:
             self.show_intro_dialog()
         self.open_breathing_prepare()
-
-        self.setup_systray()
 
         self.minimize_to_tray()
 
@@ -340,9 +340,11 @@ class MainWin(QtWidgets.QMainWindow):
             self.start_rest_timer()
         else:
             self.stop_rest_timer()
+        self.update_tooltip()
         self.update_gui(mc.mc_global.EventSource.rest_settings_changed)
 
     def on_rest_slider_value_changed(self):
+        self.update_tooltip()
         self.update_gui(mc.mc_global.EventSource.rest_slider_value_changed)
 
     def stop_rest_timer(self):
@@ -413,6 +415,7 @@ class MainWin(QtWidgets.QMainWindow):
     def on_rest_wait(self):
         mc.mc_global.rest_reminder_minutes_passed_int -= 2
         self.update_gui()
+        self.update_tooltip()
 
     def on_rest_rest(self):
         self.rest_widget = mc.gui.rest_dlg.RestDlg()
@@ -421,6 +424,7 @@ class MainWin(QtWidgets.QMainWindow):
     def on_rest_skip(self):
         mc.mc_global.rest_reminder_minutes_passed_int = 0
         self.update_gui()
+        self.update_tooltip()
 
     def on_breathing_settings_changed(self):
         self.update_breathing_timer()
@@ -753,7 +757,22 @@ class MainWin(QtWidgets.QMainWindow):
             mc.mc_global.rest_reminder_minutes_passed_int,
             mc.model.SettingsM.get().rest_reminder_interval_int
         )
-
+    
+    def update_tooltip(self):
+        #Adds tooltip on the systray icon showing the amount of time left until the next break
+        settings = mc.model.SettingsM.get()
+        if settings.rest_reminder_active:
+            self.tray_icon.setToolTip(
+                self.tr(
+                    str(
+                        mc.model.SettingsM.get().rest_reminder_interval_int
+                        - mc.mc_global.rest_reminder_minutes_passed_int
+                    )
+                    + " minute/s left until next rest"
+                )
+            )
+        else:
+            self.tray_icon.setToolTip(self.tr("Rest breaks disabled"))
 
 class SystemTray:
     def __init__(self):


### PR DESCRIPTION
Added a new function in main_win.py that updates the system tray icon's tooltip with the remaining time left until the next rest break. I also changed the order of the setup functions to avoid calling update_tooltip() before the system tray icon was initialized.