### PR TITLE
minimize_to_tray now called after show

### DIFF
--- a/mc/gui/main_win.py
+++ b/mc/gui/main_win.py
@@ -91,6 +91,7 @@ class MainWin(QtWidgets.QMainWindow):
             self.show_intro_dialog()
         self.open_breathing_prepare()
 
+        self.show()
         self.minimize_to_tray()
 
         settings = mc.model.SettingsM.get()

--- a/mindfulness-at-the-computer.py
+++ b/mindfulness-at-the-computer.py
@@ -45,7 +45,6 @@ if __name__ == "__main__":
 
     matc_qapplication.setQuitOnLastWindowClosed(False)
     matc_main_window = mc.gui.main_win.MainWin()
-    matc_main_window.show()
 
     if mc.mc_global.db_upgrade_message_str:
         # noinspection PyCallByClass


### PR DESCRIPTION
so that the application starts in "minimized to tray mode". Previously the application main settings window was shown when starting the application, or minimized (different on different systems)